### PR TITLE
Add ResourceManager unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>javafx-base</artifactId>
             <version>${javafx.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -39,6 +45,14 @@
                 <version>0.0.8</version>
                 <configuration>
                     <mainClass>game.Main</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/java/game/ResourceManagerTest.java
+++ b/src/test/java/game/ResourceManagerTest.java
@@ -1,0 +1,42 @@
+package game;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ResourceManagerTest {
+
+    @Test
+    void testCanAffordWithSufficientResources() {
+        ResourceManager manager = new ResourceManager(100, 50, 75, 0);
+        assertTrue(manager.canAfford(80, 40, 60));
+    }
+
+    @Test
+    void testCanAffordWithInsufficientResources() {
+        ResourceManager manager = new ResourceManager(100, 50, 75, 0);
+        assertFalse(manager.canAfford(120, 40, 60));
+        assertFalse(manager.canAfford(80, 60, 60));
+        assertFalse(manager.canAfford(80, 40, 80));
+    }
+
+    @Test
+    void testSpendResourcesDeductsValues() {
+        ResourceManager manager = new ResourceManager(100, 50, 75, 0);
+        manager.spendResources(30, 20, 25);
+        assertEquals(70, manager.get(ResourceType.MONEY));
+        assertEquals(30, manager.get(ResourceType.MATERIALS));
+        assertEquals(50, manager.get(ResourceType.ENERGY));
+    }
+
+    @Test
+    void testSpendResourcesDoesNotUnderflow() {
+        ResourceManager manager = new ResourceManager(30, 20, 10, 0);
+        manager.spendResources(30, 20, 10);
+        assertEquals(0, manager.get(ResourceType.MONEY));
+        assertEquals(0, manager.get(ResourceType.MATERIALS));
+        assertEquals(0, manager.get(ResourceType.ENERGY));
+        assertTrue(manager.get(ResourceType.MONEY) >= 0);
+        assertTrue(manager.get(ResourceType.MATERIALS) >= 0);
+        assertTrue(manager.get(ResourceType.ENERGY) >= 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Add JUnit 5 setup for running unit tests
- Test `canAfford` handles sufficient and insufficient resources
- Test `spendResources` deducts without underflow

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

