### PR TITLE
Add transparent resource timers to buildings

### DIFF
--- a/src/main/java/game/Building.java
+++ b/src/main/java/game/Building.java
@@ -1,11 +1,19 @@
 package game;
 
-//jjjjlo
+import javafx.animation.KeyFrame;
+import javafx.animation.KeyValue;
+import javafx.animation.Timeline;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.layout.GridPane;
+import javafx.util.Duration;
 
 public class Building {
     BuildingType buildingType;
     private int customCost; // This could be modified during gameplay
-    
+
+    private ProgressIndicator progressIndicator; // visual timer overlay
+    private Timeline resourceTimeline; // timer for generating resources
+
     // Constructor
     public Building(BuildingType buildingType) {
         this.buildingType = buildingType;
@@ -21,4 +29,60 @@ public class Building {
     public void upgradeBuilding(int upgradeCost) {
         this.customCost += upgradeCost; // The cost could change based on upgrades
     }
+
+    /**
+     * Starts a repeating timer that updates a circular progress indicator and
+     * grants resources when the timer completes.
+     */
+    public void startResourceCycle(GridPane gridPane, int x, int y, ResourceManager resources) {
+        double seconds;
+        switch (buildingType) {
+            case HOUSE -> seconds = 60;
+            case FACTORY -> seconds = 120;
+            default -> {
+                return; // no timer for other buildings
+            }
+        }
+
+        progressIndicator = new ProgressIndicator(0);
+        progressIndicator.setOpacity(0.5); // transparent overlay
+        progressIndicator.setMinSize(40, 40);
+        progressIndicator.setMaxSize(40, 40);
+        gridPane.add(progressIndicator, x, y);
+
+        resourceTimeline = new Timeline(
+            new KeyFrame(Duration.ZERO,
+                new KeyValue(progressIndicator.progressProperty(), 0)),
+            new KeyFrame(Duration.seconds(seconds), e -> {
+                switch (buildingType) {
+                    case HOUSE -> {
+                        resources.add(ResourceType.POPULATION, 10);
+                        resources.add(ResourceType.ENERGY, 50);
+                    }
+                    case FACTORY -> {
+                        resources.add(ResourceType.MONEY, 200);
+                        resources.add(ResourceType.MATERIALS, 100);
+                        resources.add(ResourceType.ENERGY, -20);
+                        resources.add(ResourceType.POPULATION, -5);
+                    }
+                }
+                if (resources.get(ResourceType.ENERGY) > 200) {
+                    resources.set(ResourceType.ENERGY, 200);
+                }
+            }, new KeyValue(progressIndicator.progressProperty(), 1))
+        );
+        resourceTimeline.setCycleCount(Timeline.INDEFINITE);
+        resourceTimeline.play();
+    }
+
+    /** Stop the timer and remove the progress indicator. */
+    public void stopResourceCycle(GridPane gridPane) {
+        if (resourceTimeline != null) {
+            resourceTimeline.stop();
+        }
+        if (progressIndicator != null) {
+            gridPane.getChildren().remove(progressIndicator);
+        }
+    }
 }
+

--- a/src/main/java/game/Main.java
+++ b/src/main/java/game/Main.java
@@ -94,64 +94,6 @@ public class Main extends Application {
         timeline.setCycleCount(Timeline.INDEFINITE);
         timeline.play();
 
-        // Add a Timeline for house effects every minute
-        Timeline houseEffectTimeline = new Timeline(new KeyFrame(Duration.seconds(60), e -> {
-            int houseCount = 0;
-            for (int x = 0; x < 100; x++) {
-                for (int y = 0; y < 100; y++) {
-                    Tile tile = map.getTile(x, y);
-                    if (tile.getBuilding() != null && tile.getBuilding().buildingType == BuildingType.HOUSE) {
-                        houseCount++;
-                    }
-                }
-            }
-            resources.add(ResourceType.POPULATION, 10 * houseCount);
-            resources.add(ResourceType.ENERGY, 50 * houseCount);
-            // Cap energy at 200
-            if (resources.get(ResourceType.ENERGY) > 200) {
-                resources.set(ResourceType.ENERGY, 200);
-            }
-            // Update the resource bar after resources change
-            resourceBar.getChildren().setAll(
-                createResourceDisplay("money.png", resources.get(ResourceType.MONEY)),
-                createResourceDisplay("materials.png", resources.get(ResourceType.MATERIALS)),
-                createResourceDisplay("energy.png", resources.get(ResourceType.ENERGY)),
-                createResourceDisplay("population.png", resources.get(ResourceType.POPULATION))
-            );
-        }));
-        houseEffectTimeline.setCycleCount(Timeline.INDEFINITE);
-        houseEffectTimeline.play();
-
-        // Add a Timeline for factory effects every 2 minutes
-        Timeline factoryEffectTimeline = new Timeline(new KeyFrame(Duration.minutes(2), e -> {
-            int factoryCount = 0;
-            for (int x = 0; x < 100; x++) {
-                for (int y = 0; y < 100; y++) {
-                    Tile tile = map.getTile(x, y);
-                    if (tile.getBuilding() != null && tile.getBuilding().buildingType == BuildingType.FACTORY) {
-                        factoryCount++;
-                    }
-                }
-            }
-            resources.add(ResourceType.MONEY, 200 * factoryCount);
-            resources.add(ResourceType.MATERIALS, 100 * factoryCount);
-            resources.add(ResourceType.ENERGY, -20 * factoryCount);
-            resources.add(ResourceType.POPULATION, -5 * factoryCount);
-            // Cap energy at 200
-            if (resources.get(ResourceType.ENERGY) > 200) {
-                resources.set(ResourceType.ENERGY, 200);
-            }
-            // Update the resource bar after resources change
-            resourceBar.getChildren().setAll(
-                createResourceDisplay("money.png", resources.get(ResourceType.MONEY)),
-                createResourceDisplay("materials.png", resources.get(ResourceType.MATERIALS)),
-                createResourceDisplay("energy.png", resources.get(ResourceType.ENERGY)),
-                createResourceDisplay("population.png", resources.get(ResourceType.POPULATION))
-            );
-        }));
-        factoryEffectTimeline.setCycleCount(Timeline.INDEFINITE);
-        factoryEffectTimeline.play();
-
         // Set the scene and show the stage
         Scene scene = new Scene(root, 800, 800); // Set scene with BorderPane as root
         primaryStage.setTitle("City Building Simulator");

--- a/src/main/java/game/Map.java
+++ b/src/main/java/game/Map.java
@@ -131,6 +131,7 @@ public class Map {
                         ((ImageView) node).setImage(buildingImage);
                     }
                 }
+                tile.getBuilding().startResourceCycle(gridPane, x, y, resources);
             } else {
                 System.out.println("Not enough resources to build this building.");
             }
@@ -142,8 +143,8 @@ public class Map {
     public void removeBuilding(GridPane gridPane, int x, int y) {
         Tile tile = tiles[x][y];
         if (tile.getBuilding() != null) {
-            // Add resources back or whatever is appropriate for demolishing
-            // For now, just remove the building and revert image to grass
+            // Remove timer overlay and building image
+            tile.getBuilding().stopResourceCycle(gridPane);
             tile.placeBuilding(null); // Remove the building
             Image grassImage = new Image(getClass().getResourceAsStream("/images/grass.png"));
             for (Node node : gridPane.getChildren()) {


### PR DESCRIPTION
## Summary
- overlay a semi-transparent circular progress indicator on buildings to show time until next resources
- start and stop per-building timelines when structures are placed or demolished
- remove global resource timers from main application logic

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a03fd3acb0832fba7b1ac2fcbee738